### PR TITLE
Remove unique constraint from k8s_container_id.

### DIFF
--- a/psql/tables/subscriptions.sql
+++ b/psql/tables/subscriptions.sql
@@ -4,6 +4,6 @@ CREATE TABLE app_runtime.subscriptions (
   url              text                                          NOT NULL,
   method           http_method                                   NOT NULL,
   payload          jsonb                                         NOT NULL,
-  k8s_container_id text                                          NOT NULL UNIQUE,
+  k8s_container_id text                                          NOT NULL,
   k8s_pod_name     text                                          NOT NULL
 );


### PR DESCRIPTION
The same container may have multiple subscriptions associated with it.
As such, the only unique key here should be the subscription ID.